### PR TITLE
I'm not sure if this behavior is intentional or not, but prodplot(happy, ~ happy, 'tile') does not work because two rectangles had the same left boundary and ddply was only splitting by left boundaries in col_labels.

### DIFF
--- a/R/labels.r
+++ b/R/labels.r
@@ -46,7 +46,7 @@ find_col_level <- function(df) {
 col_labels <- function(df) {
   vars <- setdiff(names(df), c(".wt", "l", "r", "t", "b", "level"))
   
-  ddply(df, "l", function(df) {
+  ddply(df, c("l", "r", "t", "b"), function(df) {
     # If width is constant, draw in the middle, otherwise draw on the left.
     widths <- df$r - df$l
     widths <- widths[widths != 0]


### PR DESCRIPTION
prodplot(happy, ~ happy, 'tile')
did not work due to two groups having the same left boundary and ddply was only splitting by left boundaries in col_labels.
