### PR TITLE
refactor plyr::ddply usage

### DIFF
--- a/tests/testthat/helper-division.r
+++ b/tests/testthat/helper-division.r
@@ -24,14 +24,14 @@ calc_area <- function(mat, divider) {
 #' Standardise weight and area to sum to 1 within a level, and calulate ratio
 #' between the two.
 calc_ratio <- function(dims) {
-  ddply(dims, "level", function(df) {
-    transform(df,
-      .wt = prop(.wt),
-      area = prop(area),
-      ratio = prop(area) / prop(.wt))
+  dims <- lapply(split(dims, dims$level), function(df) {
+    df$.wt <- prop(df$.wt)
+    df$area <- prop(df$area)
+    df$ratio <- df$area / df$.wt
+    return(df)
   })
+  do.call(rbind, dims)
 }
-
 
 #' Expectation: output areas are proportional to input weights
 has_proportional_areas <- function() {


### PR DESCRIPTION
Made a choice to switch to a {base} equivalent here as opposed to {dplyr}, maybe that's not the right decision. Because of the problem of `split()` dropping missing levels, we have some extra overhead here -- I don't have enough context to know if that defensive coding is needed. The diff would look cleaner if we could ignore the `NA` case.